### PR TITLE
feat: migrate web_search_mcp to support Tavily as primary search provider

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -20,3 +20,4 @@ PORT=8443
 # ALPHA_VANTAGE_KEY=your-key
 # FRED_API_KEY=your-key
 # GOOGLE_CSE_ID=your-custom-search-engine-id
+# TAVILY_API_KEY=tvly-your-tavily-api-key

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ numpy>=1.24.0
 requests>=2.32.0
 edge-tts>=7.0.0
 aiosqlite>=0.20.0
+tavily-python>=0.5.0

--- a/web_search_mcp/server.py
+++ b/web_search_mcp/server.py
@@ -22,6 +22,8 @@ server = Server("web-search-mcp")
 GOOGLE_API_KEY = os.environ.get("GOOGLE_API_KEY", "")
 # Google Custom Search Engine ID — if not set, uses fallback
 GOOGLE_CSE_ID = os.environ.get("GOOGLE_CSE_ID", "")
+# Tavily API key — when set, Tavily is preferred for web search
+TAVILY_API_KEY = os.environ.get("TAVILY_API_KEY", "")
 
 USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
 
@@ -131,6 +133,27 @@ def duckduckgo_search(query: str, num_results: int = 5) -> list[dict]:
             pass
 
     return results[:num_results]
+
+
+def tavily_search(query: str, num_results: int = 5) -> list[dict]:
+    """Use Tavily Search API. Returns the same {title, url, snippet} shape."""
+    from tavily import TavilyClient
+
+    client = TavilyClient(api_key=TAVILY_API_KEY)
+    response = client.search(
+        query=query,
+        max_results=min(num_results, 10),
+        search_depth="basic",
+    )
+
+    results = []
+    for item in response.get("results", []):
+        results.append({
+            "title": item.get("title", ""),
+            "url": item.get("url", ""),
+            "snippet": item.get("content", ""),
+        })
+    return results
 
 
 def geocode_location(location: str) -> tuple[float, float, str]:
@@ -272,8 +295,13 @@ def extract_page_content(url: str, max_chars: int = 3000) -> str:
 
 def deep_web_search(query: str, num_results: int = 5) -> dict:
     """Enhanced search: initial results + page content extraction + auto-refine."""
-    # Phase 1: initial search
-    if GOOGLE_API_KEY and GOOGLE_CSE_ID:
+    # Phase 1: initial search — prefer Tavily, then Google CSE, then DuckDuckGo
+    if TAVILY_API_KEY:
+        try:
+            results = tavily_search(query, num_results)
+        except Exception:
+            results = duckduckgo_search(query, num_results)
+    elif GOOGLE_API_KEY and GOOGLE_CSE_ID:
         try:
             results = google_custom_search(query, num_results)
         except Exception:
@@ -295,7 +323,9 @@ def deep_web_search(query: str, num_results: int = 5) -> dict:
     if avg_snippet < 30 and len(results) < 3:
         refined_query = f"{query} detailed information guide"
         try:
-            if GOOGLE_API_KEY and GOOGLE_CSE_ID:
+            if TAVILY_API_KEY:
+                extra = tavily_search(refined_query, 3)
+            elif GOOGLE_API_KEY and GOOGLE_CSE_ID:
                 extra = google_custom_search(refined_query, 3)
             else:
                 extra = duckduckgo_search(refined_query, 3)
@@ -820,8 +850,13 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                 result = deep_web_search(query, num)
                 return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
-            # Standard search: Google CSE first, fall back to DuckDuckGo
-            if GOOGLE_API_KEY and GOOGLE_CSE_ID:
+            # Standard search: prefer Tavily, then Google CSE, then DuckDuckGo
+            if TAVILY_API_KEY:
+                try:
+                    results = tavily_search(query, num)
+                except Exception:
+                    results = duckduckgo_search(query, num)
+            elif GOOGLE_API_KEY and GOOGLE_CSE_ID:
                 try:
                     results = google_custom_search(query, num)
                 except Exception:
@@ -938,6 +973,8 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         # Redact API keys from error messages
         if GOOGLE_API_KEY:
             error_msg = error_msg.replace(GOOGLE_API_KEY, "[REDACTED]")
+        if TAVILY_API_KEY:
+            error_msg = error_msg.replace(TAVILY_API_KEY, "[REDACTED]")
         return [TextContent(type="text", text=json.dumps({"error": error_msg}))]
 
 


### PR DESCRIPTION
## Summary
- Added Tavily as a first-class, configurable search backend in `web_search_mcp/server.py`
- When `TAVILY_API_KEY` is set, Tavily is preferred over Google CSE for `web_search` and `deep_web_search` calls
- Existing Google CSE → DuckDuckGo fallback chain is fully preserved
- Image, video, academic, and Wikipedia search paths are unchanged

## Files changed
- `web_search_mcp/server.py` — Added `TAVILY_API_KEY` env read, `tavily_search()` helper, updated provider-selection in standard search, deep search, and auto-refine paths, added API key redaction
- `requirements.txt` — Added `tavily-python>=0.5.0`
- `.env.template` — Documented optional `TAVILY_API_KEY`

## Dependency changes
- Added `tavily-python>=0.5.0` to `requirements.txt`

## Environment variable changes
- Added optional `TAVILY_API_KEY` — when set, Tavily becomes the preferred web search provider

## Notes for reviewers
- This is an **additive** migration: no existing functionality is removed or broken
- Tavily covers web search only; image/video/weather/academic paths are unaffected
- The `tavily_search()` helper returns the same `{title, url, snippet}` shape as `google_custom_search` and `duckduckgo_search`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Automated Review

- Passed after 1 attempt(s)
- Final review: The Tavily migration is well-implemented and correct. All three files listed in the plan are updated. Tavily SDK usage is valid (TavilyClient, .search() with correct params, correct response field mapping). The additive fallback chain (Tavily → Google CSE → DuckDuckGo) is consistently applied in both web_search and deep_web_search. API key redaction and env var documentation are in place. Two minor issues noted but neither blocks approval.
